### PR TITLE
fix image crop.data -> copy

### DIFF
--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -196,6 +196,10 @@ void Mainloop::camera_callback(const void *img, UNUSED size_t len, const struct 
 			_camera->height / 2 - _optical_flow->getImageHeight() / 2,
 			_optical_flow->getImageWidth(), _optical_flow->getImageHeight());
 	cv::Mat cropped_image = frame_gray(crop);
+  cv::Mat cropped;
+	// Copy the data into new matrix -> cropped_image.data can not be used in calcFlow()...
+	cropped_image.copyTo(cropped);
+  cropped_image.deallocate();
 
 #if DEBUG_LEVEL
 	imshow(_window_name, frame_gray);
@@ -220,8 +224,9 @@ void Mainloop::camera_callback(const void *img, UNUSED size_t len, const struct 
 		ERROR("img_time_us > UINT32_MAX");
 	}
 
-	int flow_quality = _optical_flow->calcFlow(cropped_image.data, (uint32_t)img_time_us, dt_us, flow_x_ang, flow_y_ang);
+	int flow_quality = _optical_flow->calcFlow(cropped.data, (uint32_t)img_time_us, dt_us, flow_x_ang, flow_y_ang);
 
+  cropped.deallocate();
 	_camera_prev_timestamp = img_time_us;
 
 	// check if flow is ready/integrated -> flow output rate


### PR DESCRIPTION
`cv::Mat cropped_image = frame_gray(crop);` does not copy the image which results in bad data for `cropped_image.data` inside `calcFlow()`.