### PR TITLE
gyro calibration fix and add mavlink time offset

### DIFF
--- a/src/bmi160.cpp
+++ b/src/bmi160.cpp
@@ -333,12 +333,12 @@ read_fifo_read_data:
 				_gyro_offsets = gyro;
 			} else {
 				_gyro_offsets += gyro;
-				_gyro_offsets /= 2.0;
 			}
 			_calibration_samples_counter--;
 
 			// last sample? save offsets
 			if (!_calibration_samples_counter) {
+				_gyro_offsets /= BMI160_SAMPLES_TO_CALIBRATE;
 				_calibration_save();
 			}
 		} else {

--- a/src/mainloop.h
+++ b/src/mainloop.h
@@ -52,7 +52,7 @@ public:
 	void shutdown();
 
 	void camera_callback(const void *img, size_t len, const struct timeval *timestamp);
-	void highres_imu_msg_callback(const mavlink_highres_imu_t *msg);
+	void set_mavlink_time(const mavlink_highres_imu_t *msg);
 	void *camera_thread();
 
 private:
@@ -63,6 +63,8 @@ private:
 
 	uint64_t _camera_initial_timestamp = 0;
 	uint64_t _camera_prev_timestamp = 0;
+	uint64_t _mavlink_time_usec = 0;
+	uint64_t _offset_time_usec = 0;
 
 	Camera *_camera;
 	OpticalFlowOpenCV *_optical_flow;


### PR DESCRIPTION
I fixed the gyro calibration and added a time offset for the optical flow message so that it is in sync with the imu messages from the autopilot and we don't need to change the Firmware/estimator.