### PR TITLE
orientation and rate update

### DIFF
--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -327,10 +327,10 @@ void Mainloop::camera_callback(const void *img, UNUSED size_t len, const struct 
 	mavlink_optical_flow_rad_t msg;
 	msg.time_usec = _offset_timestamp_usec + img_time_us;
 	msg.integration_time_us = dt_us;
-	msg.integrated_x = flow_y_ang; //switch to match correct directions
-	msg.integrated_y = -flow_x_ang; //switch to match correct directions
-	msg.integrated_xgyro = gyro_data.x;
-	msg.integrated_ygyro = gyro_data.y;
+	msg.integrated_x = flow_x_ang;
+	msg.integrated_y = flow_y_ang;
+	msg.integrated_xgyro = -gyro_data.y; // switch to match pixel directions
+	msg.integrated_ygyro = gyro_data.x; // switch to match pixel directions
 	msg.integrated_zgyro = gyro_data.z;
 	msg.time_delta_distance_us = 0;
 	msg.distance = -1.0;

--- a/src/mavlink_tcp.h
+++ b/src/mavlink_tcp.h
@@ -40,6 +40,8 @@
 
 #include "pollable.h"
 
+#define HIGHRES_IMU_INTERVAL_US 4000.0f
+
 class Mavlink_TCP : public Pollable {
 public:
 	virtual ~Mavlink_TCP();
@@ -52,6 +54,7 @@ public:
 	void highres_imu_msg_subscribe(void (*callback)(const mavlink_highres_imu_t *msg, void *data), const void *data);
 
 	int optical_flow_rad_msg_write(mavlink_optical_flow_rad_t *msg);
+	int set_highres_rate(float interval_us);
 private:
 	struct sockaddr_in _sockaddr;
 
@@ -60,6 +63,6 @@ private:
 	void (*_highres_imu_msg_callback)(const mavlink_highres_imu_t *msg, void *data) = NULL;
 	const void *_highres_imu_msg_callback_data;
 
-	const uint8_t _system_id = 100;
-	const uint8_t _component_id = 1;
+	const uint8_t _system_id = 1; // TODO default is 1, but check with heartbeat
+	const uint8_t _component_id = MAV_COMP_ID_CAMERA;
 };


### PR DESCRIPTION
The orientation change also needs to go into master. I didn't take the default `SENS_FLOW_ROT` of 6 into account... (before I tested with the not rotated qgc message)

The seconds thing is a `HIGHRES_IMU` rate increase. Default is just 50 Hz which is lower than the frame rate...